### PR TITLE
Check if belt is not nil

### DIFF
--- a/objects/balancer.lua
+++ b/objects/balancer.lua
@@ -137,6 +137,12 @@ function balancer_functions.recalculate_nth_tick(balancer_index)
         local stack_part = storage.parts[part]
         for _, belt in pairs(stack_part.output_belts) do
             local stack_belt = storage.belts[belt]
+			
+	    -- Check if belt is not a nil value
+	    if not stack_belt or stack_belt == nil then
+	        goto continue
+	    end
+			
             local belt_speed = stack_belt.entity.prototype.belt_speed
             local ticks_per_tile = 0.25 / belt_speed
             local nth_tick = math.floor(ticks_per_tile)
@@ -145,6 +151,7 @@ function balancer_functions.recalculate_nth_tick(balancer_index)
                 break
             end
             tick_list[nth_tick] = nth_tick
+	    ::continue::
         end
 
         if run_on_tick_override then

--- a/objects/part.lua
+++ b/objects/part.lua
@@ -260,7 +260,12 @@ function part_functions.remove(entity, buffer)
 
     for _, belt_index in pairs(part.output_belts) do
         local belt = storage.belts[belt_index]
-
+		
+        -- Check if belt is not a nil value
+        if not belt or belt == nil then
+        	goto continue
+        end
+		
         -- only remove lanes, if this is splitter
         if belt.type == "splitter" then
             local _, from_pos = belt_functions.get_input_output_pos_splitter(belt.entity)


### PR DESCRIPTION
This solves one of the crashes in Factorio v2.0.13 upon interacting with a splitter next to an underground belt